### PR TITLE
Fix SyntaxError in stats.py

### DIFF
--- a/regressors/stats.py
+++ b/regressors/stats.py
@@ -251,7 +251,7 @@ def summary(clf, X, y, xlabels=None):
     )
     try:
         coef_df['Estimate'] = np.concatenate(
-            (np.round(np.array([clf.intercept_]), 6), np.round((clf.coef_), 6))
+            (np.round(np.array([clf.intercept_]), 6), np.round((clf.coef_), 6)))
     except Exception as e:
         coef_df['Estimate'] = np.concatenate(
             (


### PR DESCRIPTION
This pull-request fixes SyntaxError in stats.py.

```
python -c "from regressors import stats"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "D:\work\tmp\venv\Lib\site-packages\regressors\stats.py", line 253
    coef_df['Estimate'] = np.concatenate(
                                        ^
SyntaxError: '(' was never closed
```

https://colab.research.google.com/drive/17rOPdHFef0AuHRdSvNZ44852WDpJBvyN?usp=sharing
